### PR TITLE
Fixes to allow aurum to recover from au init failure without failing …

### DIFF
--- a/aurum/au.py
+++ b/aurum/au.py
@@ -29,7 +29,7 @@ __version__ = "0.1"
 
 import argparse
 
-from .base import execute_commands
+from aurum.base import execute_commands
 import aurum.constants as cons
 
 

--- a/aurum/base.py
+++ b/aurum/base.py
@@ -47,6 +47,9 @@ def get_cwd():
     return Path(os.getcwd())
 
 
+#######
+# TODO: Figure out whether we can stick with only one of DEFAULT_DIRS or get_default_dirs.
+# Not sure why we're duplicating this here.
 DEFAULT_DIRS = [
     get_cwd() / cons.REPOSITORY_DIR,
     get_cwd() / "src",

--- a/aurum/commands.py
+++ b/aurum/commands.py
@@ -166,12 +166,12 @@ def run_load(parsed_result: argparse.Namespace, skip_package_install: bool = Fal
 
 def create_default_dirs() -> None:
     for path in base.DEFAULT_DIRS:
-        if path.exists():
+        if path.exists() and path.parts[-1] != cons.REPOSITORY_DIR and os.listdir(path) != ['.keep']:
             logging.error(f"Can't create {path} directory. Already exists.")
             sys.exit(1)
         logging.debug(f"Creating dir {path}")
 
-        os.makedirs(path)
+        os.makedirs(path, exist_ok=True)
         Path(path, '.keep').touch()  # Needed to allow adding an empty directory to git
 
 


### PR DESCRIPTION
This is relative to card #567 on an issue I found when testing aurum. In that specific instance, the git commit executed during au init failed because my local git did not have a user name and email setup. After setting up the global configs and trying au init again, it failed because the directory .au and its subdirectories were already created. This fix, will disregard the existing directions created if they're empty, reflecting a condition of failure during au init and allow recovery without requiring the user to manually remove the .au directory.