### PR TITLE
Change to push branches and tags to remote repository

### DIFF
--- a/aurum/base.py
+++ b/aurum/base.py
@@ -343,6 +343,11 @@ def end_experiment() -> bool:
         git.commit(f"Experiment ID {theorem.experiment_id}", commit_msg)
         git.tag(theorem.experiment_id, commit_msg)
 
+        # git push all branches
+        git.push()
+        # git push all tags
+        git.push_tags()
+
         return True
 
     return False

--- a/aurum/git.py
+++ b/aurum/git.py
@@ -26,8 +26,6 @@ import os
 import subprocess
 import sys
 
-from typing import List
-
 
 class GitCommandError(Exception):
     pass
@@ -45,7 +43,6 @@ def check_git():
 
 
 def running_from_git_repo(cwd: str = "") -> bool:
-
     if cwd == "":
         cwd = os.getcwd()
 
@@ -62,7 +59,6 @@ def running_from_git_repo(cwd: str = "") -> bool:
 
 
 def get_git_repo_root(cwd: str = '') -> str:
-
     if cwd == "":
         cwd = os.getcwd()
 
@@ -148,13 +144,34 @@ def current_branch_name() -> str:
 
 
 def push() -> str:
-    sub = run_git('push')
+    if not has_remote():
+        return ''
+    sub = run_git('push', '--all')
     output, error = sub.communicate()
-
     if sub.returncode != 0:
-        raise GitCommandError(f"Failed to run 'git push': {error}")
+        raise GitCommandError(f"Failed to run 'git push --all': {error}")
 
     return output.decode('utf-8').replace('\n', '')
+
+
+def push_tags() -> str:
+    if not has_remote():
+        return ''
+    sub = run_git('push', '--tags')
+    output, error = sub.communicate()
+    if sub.returncode != 0:
+        raise GitCommandError(f"Failed to run 'git push --tags': {error}")
+    return output.decode('utf-8').replace('\n', '')
+
+
+def has_remote() -> bool:
+    sub = run_git('remote', 'show')
+    output, error = sub.communicate()
+    if sub.returncode != 0:
+        raise GitCommandError(f"Failed to run 'git remote show': {error} /n Please configure a remote repository")
+
+    output = output.decode('utf-8').replace('\n', '')
+    return bool(output and output.strip())
 
 
 def add(*filenames: str, cwd: str = '') -> str:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='aurum',
-    version='0.1.15',
+    version='0.1.16',
     description='Data and Code Versioning for Data Scientists',
     author='Adriano Marques, Nathan Martins, Thales Ribeiro',
     author_email='adriano@xnv.io, nathan@xnv.io, thales@xnv.io',

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -96,6 +96,18 @@ class TestExport(unittest.TestCase):
         if proc.returncode != 0:
             raise Exception(f"Failed: {err}")
 
+        add_remote_proc = subprocess.Popen(
+            [f"git remote add origin {self.repository_path}/.git "],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            shell=True,
+            cwd=self.repository_path,
+        )
+
+        out, err = add_remote_proc.communicate()
+        if add_remote_proc.returncode != 0:
+            raise Exception(f"Failed: {err}")
+
         Theorem().requirements_did_change(b_hash)
 
         self.experiment_id = Theorem().experiment_id


### PR DESCRIPTION
From now on, once an experiment has ended, Aurum pushes all the branches and tags to a remote repo